### PR TITLE
Add basic blog section

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,36 @@
+import { notFound } from 'next/navigation';
+import { posts } from '@/lib/posts';
+
+interface Props {
+  params: { slug: string };
+}
+
+export function generateStaticParams() {
+  return posts.map((post) => ({ slug: post.slug }));
+}
+
+export function generateMetadata({ params }: Props) {
+  const post = posts.find((p) => p.slug === params.slug);
+  return {
+    title: post?.title ?? 'Post',
+  };
+}
+
+export default function BlogPost({ params }: Props) {
+  const post = posts.find((p) => p.slug === params.slug);
+  if (!post) {
+    notFound();
+  }
+
+  return (
+    <article className='text-gray-400'>
+      <h1 className='text-white font-medium text-lg mb-4'>{post!.title}</h1>
+      <p className='text-sm mb-8'>{post!.date}</p>
+      <div className='space-y-4'>
+        {post!.content.map((p, i) => (
+          <p key={i}>{p}</p>
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import { posts } from '@/lib/posts';
+
+export const metadata = {
+  title: 'Blog',
+};
+
+export default function BlogPage() {
+  return (
+    <div className='text-gray-400'>
+      <h1 className='text-white font-medium text-lg mb-8'>Blog</h1>
+      <ul className='flex flex-col gap-6'>
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <Link href={`/blog/${post.slug}`} className='text-white underline'>
+              {post.title}
+            </Link>
+            <p className='text-sm'>{post.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import { posts } from '@/lib/posts';
 
 export default function Home() {
 	return (
@@ -33,27 +34,41 @@ export default function Home() {
 				yet :)
 			</p>
 
-			<p className='mt-16'>
-				you can find more of my work on{' '}
-				<a
-					href='https://github.com/DarrenBaldwin07'
-					target='_blank'
-					className='underline'>
-					Github
-				</a>{' '}
-				and contact me via{' '}
-				<a
-					href='https://x.com/darrenbaldwinjr'
-					target='_blank'
-					className='underline'>
-					X
-				</a>{' '}
-				or{' '}
-				<a href='mailto:darren@darrenbaldwin.dev' className='underline'>
-					email
-				</a>
-				.
-			</p>
-		</div>
-	);
+                        <p className='mt-16'>
+                                you can find more of my work on{' '}
+                                <a
+                                        href='https://github.com/DarrenBaldwin07'
+                                        target='_blank'
+                                        className='underline'>
+                                        Github
+                                </a>{' '}
+                                and contact me via{' '}
+                                <a
+                                        href='https://x.com/darrenbaldwinjr'
+                                        target='_blank'
+                                        className='underline'>
+                                        X
+                                </a>{' '}
+                                or{' '}
+                                <a href='mailto:darren@darrenbaldwin.dev' className='underline'>
+                                        email
+                                </a>
+                                .
+                        </p>
+
+                        <div className='mt-16'>
+                                <h2 className='text-white font-medium text-md mb-4'>Blog Posts</h2>
+                                <ul className='flex flex-col gap-4'>
+                                        {posts.map((post) => (
+                                                <li key={post.slug}>
+                                                        <Link href={`/blog/${post.slug}`} className='underline text-white'>
+                                                                {post.title}
+                                                        </Link>
+                                                        <p className='text-sm'>{post.description}</p>
+                                                </li>
+                                        ))}
+                                </ul>
+                        </div>
+                </div>
+        );
 }

--- a/lib/posts.ts
+++ b/lib/posts.ts
@@ -1,0 +1,20 @@
+export interface Post {
+  slug: string;
+  title: string;
+  description: string;
+  date: string;
+  content: string[];
+}
+
+export const posts: Post[] = [
+  {
+    slug: 'hello-world',
+    title: 'Hello World',
+    description: 'A short sample blog post to get things started.',
+    date: '2024-05-01',
+    content: [
+      'Welcome to your new blog!',
+      'This is a simple example post to demonstrate how blog pages work.',
+    ],
+  },
+];


### PR DESCRIPTION
## Summary
- add minimal post data source
- list blog posts on landing page
- create blog index
- show simple post page

## Testing
- `pnpm lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683c8fdef0088322ad1dae7d371f0af9